### PR TITLE
Remove extra word in tutorial text

### DIFF
--- a/modern_1_intro.ipynb
+++ b/modern_1_intro.ipynb
@@ -1179,7 +1179,7 @@
    "metadata": {},
    "source": [
     "So far, so good. What if you wanted to select the rows whose origin was Chicago O'Hare (`ORD`) or Des Moines International Airport (DSM).\n",
-    "Well, `.loc` wants `[row_indexer, column_indexer]` so let's wrap our the two elements of our row indexer (the list of carriers and the list of origins) in a tuple to make it a single unit:"
+    "Well, `.loc` wants `[row_indexer, column_indexer]` so let's wrap the two elements of our row indexer (the list of carriers and the list of origins) in a tuple to make it a single unit:"
    ]
   },
   {


### PR DESCRIPTION
original reads '...so let's wrap our the two elements of our row indexer (the list of carriers and the list of origins) in a tuple...'
remove first 'our'
edited reads '...so let's wrap the two elements of our row indexer (the list of carriers and the list of origins) in a tuple...'