### PR TITLE
Made mostly illegible graph legible

### DIFF
--- a/modern_2_method_chaining.ipynb
+++ b/modern_2_method_chaining.ipynb
@@ -427,6 +427,7 @@
     "fig, ax = plt.subplots(figsize=(15, 5))\n",
     "sns.boxplot(x='turn', y='dep_delay', data=flights, ax=ax)\n",
     "sns.despine()"
+    "ax.set_ylim(-50, 50)"
    ]
   },
   {


### PR DESCRIPTION
Most of the flight delays are concentrated in [-50; 50]. The previous scale made their box plot distribution essentially illegible.