### PR TITLE
More Pandaesque way of getting the mode of a Series

### DIFF
--- a/modern_3_indexes.ipynb
+++ b/modern_3_indexes.ipynb
@@ -2376,7 +2376,7 @@
     "    '''\n",
     "    Arbitrarily break ties.\n",
     "    '''\n",
-    "    return x.value_counts().index[0]\n",
+    "    return x.mode().iloc[0]\n",
     "\n",
     "aggfuncs = {'tmpf': 'mean', 'relh': 'mean',\n",
     "            'sped': 'mean', 'mslp': 'mean',\n",


### PR DESCRIPTION
The grouping is 3 times faster, with the dedicated `mode()` method.